### PR TITLE
Updated Scripts So They Work Within Windows

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Allows Windows users to run the cms.
+set DEBUG=cms:*;
+nodemon --exec babel-node app.js

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+nodemon --exec mocha --compilers js:babel/register

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Just a CMS written in ES6 with NodeJS",
   "main": "init.js",
   "scripts": {
-    "start": "DEBUG=cms:* nodemon --exec babel-node app.js",
-    "test": "nodemon --exec ./node_modules/.bin/mocha --compilers js:babel/register"
+    "start": "sh ./bin/start.sh",
+    "test": "sh ./bin/test.sh"
   },
   "author": "Joshua Kidd",
   "license": "MIT",

--- a/test/route-test.js
+++ b/test/route-test.js
@@ -1,10 +1,10 @@
-var chai = require('chai');
-var expect = chai.expect;
-var should = chai.should();
+const chai = require('chai');
+const expect = chai.expect;
+const should = chai.should();
 
 describe('test', () => {
   it('should be ok', () => {
-    var foo = 'test';
+    const foo = 'test';
     expect(foo).to.be.a('string');
   });
 });


### PR DESCRIPTION
Based on how you were setting the DEBUG variable, it was not running in windows.  I've gone ahead and extracted the `npm start` and `npm test` scripts out to their own respective scripts within the newly created bin directory.  This also allows for more control over the scripts, if need be, in the future.

Note: To run, Windows users still need `cygwin` or some variant thereof.
